### PR TITLE
Spec %

### DIFF
--- a/src/s21_sprintf/s21_sprintf.c
+++ b/src/s21_sprintf/s21_sprintf.c
@@ -20,6 +20,7 @@ int s21_sprintf(char* str, const char* format, ...) {
       if (format[ptr] == 'f')
         specF(str, va_arg(args, double), &shiftStr, &specs);
       if (format[ptr] == 'd') specD(str, &specs, &args, &shiftStr);
+      if (format[ptr] == '%') specPercent(str, &shiftStr);
 
       str += shiftStr;
     } else {

--- a/src/s21_sprintf/s21_sprintf.h
+++ b/src/s21_sprintf/s21_sprintf.h
@@ -9,6 +9,7 @@
 #include "spec_c.h"
 #include "spec_d.h"
 #include "spec_f.h"
+#include "spec_percent.h"
 #include "spec_s.h"
 
 int s21_sprintf(char *str, const char *format, ...);

--- a/src/s21_sprintf/spec_percent.c
+++ b/src/s21_sprintf/spec_percent.c
@@ -1,0 +1,6 @@
+#include "spec_percent.h"
+
+void specPercent(char* str, int* shiftStr) {
+  *str = '%';
+  *shiftStr += 1;
+}

--- a/src/s21_sprintf/spec_percent.h
+++ b/src/s21_sprintf/spec_percent.h
@@ -1,0 +1,8 @@
+#ifndef SPEC_PERCENT_H
+#define SPEC_PERCENT_H
+
+#include "../common/basetypes.h"
+
+void specPercent(char* str, int* shiftStr);
+
+#endif

--- a/src/test/unittest.c
+++ b/src/test/unittest.c
@@ -1098,6 +1098,23 @@ START_TEST(test_sprintf_spec_d_ld_hd_0) {
   ck_assert_str_eq(resString, expString);
 }
 END_TEST
+START_TEST(test_sprintf_spec_percent) {
+  char resString[128];
+  char expString[128];
+  int resNum = s21_sprintf(resString, "a, %%, c");
+  int expNum = sprintf(expString, "a, %%, c");
+  ck_assert_int_eq(resNum, expNum);
+  ck_assert_str_eq(resString, expString);
+  resNum = s21_sprintf(resString, "%5f, %%, %5s", 303.22, "YES");
+  expNum = sprintf(expString, "%5f, %%, %5s", 303.22, "YES");
+  ck_assert_int_eq(resNum, expNum);
+  ck_assert_str_eq(resString, expString);
+  //resNum = s21_sprintf(resString, "%5f, %5%, %5s", 303.22, "YES");
+  //expNum = sprintf(expString, "%5f, %5%, %5s", 303.22, "YES");
+  //ck_assert_int_eq(resNum, expNum);
+  //ck_assert_str_eq(resString, expString);
+}
+END_TEST
 
 void testSprintf(TCase *tc_core) {
   tcase_add_test(tc_core, test_sprintf_spec_c);
@@ -1111,6 +1128,7 @@ void testSprintf(TCase *tc_core) {
   tcase_add_test(tc_core, test_set_specs_basic);
   tcase_add_test(tc_core, test_sprintf_spec_d_d);
   tcase_add_test(tc_core, test_sprintf_spec_d_ld_hd_0);
+  tcase_add_test(tc_core, test_sprintf_spec_percent);
 }
 
 // ================================ -+- trim -+- =====================

--- a/src/test/unittest.c
+++ b/src/test/unittest.c
@@ -1109,10 +1109,10 @@ START_TEST(test_sprintf_spec_percent) {
   expNum = sprintf(expString, "%5f, %%, %5s", 303.22, "YES");
   ck_assert_int_eq(resNum, expNum);
   ck_assert_str_eq(resString, expString);
-  //resNum = s21_sprintf(resString, "%5f, %5%, %5s", 303.22, "YES");
-  //expNum = sprintf(expString, "%5f, %5%, %5s", 303.22, "YES");
-  //ck_assert_int_eq(resNum, expNum);
-  //ck_assert_str_eq(resString, expString);
+  // resNum = s21_sprintf(resString, "%5f, %5%, %5s", 303.22, "YES");
+  // expNum = sprintf(expString, "%5f, %5%, %5s", 303.22, "YES");
+  // ck_assert_int_eq(resNum, expNum);
+  // ck_assert_str_eq(resString, expString);
 }
 END_TEST
 


### PR DESCRIPTION
Собственно в чем нюанс, оригинальный спецификатор работает только так: sprintf(str, "%%") - в строку str заносится %. Наш работает и так как оригинальный и так тоже: s21_sprintf(str, "%5%") - в строку str заносится %, 5 просто игнорируется. Есть ли смысл ковыряться дальше, чтобы он выводил ошибку, как делает оригинальный?